### PR TITLE
chore: remove unnecessary console.log and unused function param

### DIFF
--- a/src/vue-let-it-snow.vue
+++ b/src/vue-let-it-snow.vue
@@ -62,8 +62,7 @@ export default {
         }
     },
     watch: {
-        show: function (newShow, oldShow) {
-            console.log(newShow, oldShow)
+        show: function (newShow) {
             if (newShow) {
                 this.myShow = true;
                 this.toHide = false;


### PR DESCRIPTION
remove unnecessary console.log just to keep browser console clean